### PR TITLE
Efw 463 schedule travis skip

### DIFF
--- a/barney.yaml
+++ b/barney.yaml
@@ -35,3 +35,31 @@ images:
     - - sh
       - -c
       - mkdir /var/lock && opkg install --force-downgrade /mfw-packages/*/*
+
+  ################
+  #
+  # Validate non-code files
+  #
+  #########
+
+  tests/internal/renovate-json5-floor:
+    entry:
+      mutables:
+        - /etc        # for error unable to clean up mess surrounding './etc/apache2' before installing another version: Read-only file system
+        - /usr        # for apt
+        - /var/cache  # for apt
+        - /var/lib    # for apt
+        - /var/log    # for apt
+    units:
+    - image: barney.ci/debian%minbase
+    - image: barney.ci/debian%network
+
+  tests/renovate-json5:
+    units:
+    - floor: .%tests/internal/renovate-json5-floor
+      sources:
+      - github.com/untangle/support-diagnostics # to get sources under stable path
+      build: |
+        apt update
+        apt install -y node-json5
+        json5 --validate /src/github.com/untangle/support-diagnostics/renovate.json5

--- a/meta.yaml
+++ b/meta.yaml
@@ -41,4 +41,14 @@ x-github-bridge:
           branch-re: ^master$
         - type: push
           branch-re: ^master$
+
+    - image: tests/renovate-json5
+      events:
+        - type: pull_request
+          branch-re: ^main$
+        - type: merge_group
+          branch-re: ^main$
+        - type: push
+          branch-re: ^main$
+
 epoch: 1

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,11 +1,14 @@
 {
     "automergeSchedule": ["at any time"],
+    commitMessage: "{{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}} [skip travis]",
 
     packageRules: [
         {
             "matchDatasources": ["custom.bar"],
             "matchPackageNames": ["code.arista.io/infra/barney/barnzilla-repos"],
-            "automergeSchedule": ["at any time"]
+            "automergeSchedule": ["* 0-3 * * *"],
+            "timezone": "Etc/UTC",
+            commitMessage: "{{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}} [skip travis]",
         }
     ]
 }


### PR DESCRIPTION
https://awakesecurity.atlassian.net/browse/EFW-463

I'm skipping Travis-ci for BAR updates and changing schedule for auto merge for barnzilla-repos
I on purpose, add the changes to repos under Untangle org that has no Travis checks in case we want to add them later

depends on: https://github.com/untangle/support-diagnostics/pull/12