### PR TITLE
NGFW-13599 Fixed dictionary modifcation error while iterating over the keys

### DIFF
--- a/support_diagnostics/analyzer_result.py
+++ b/support_diagnostics/analyzer_result.py
@@ -90,7 +90,7 @@ class AnalyzerResult:
             for k in data:
                 format_attributes[k] = data[k]
 
-        for field in self.results:
+        for field in list(self.results):
             if self.results[field] is not None:
                 ## Process as list.
                 messages = self.results[field]


### PR DESCRIPTION
Fixes,
```
[root @ arista] ~ # support-diagnostics
support-diagnostics version: .6                                                                                                                                                               

Checking for updates...Update: download: Cannot open https://updates.untangle.com/support_diagnostics.tgz

Collecting & analyzing.....Traceback (most recent call last):
  File "/bin/support-diagnostics", line 93, in <module>
    main()
  File "/bin/support-diagnostics", line 85, in main
    analyzer_results[analyzer_class] = analyzer.analyze(collector_results)
  File "/usr/lib/python3/dist-packages/support_diagnostics/platforms/debian/analyzers/system.py", line 45, in analyze
    result.format(format_fields)
  File "/usr/lib/python3/dist-packages/support_diagnostics/analyzer_result.py", line 93, in format
    for field in self.results:
RuntimeError: dictionary keys changed during iteration
[root @ arista] ~ # find / -name support-diagnostics
find: '/proc/3583/task/3583/net': Invalid argument
find: '/proc/3583/net': Invalid argument
/usr/bin/support-diagnostics
```


This is what we get after the fix,
![image](https://github.com/user-attachments/assets/ca08e595-82c2-4a8d-9bf9-bfc841e172df)
