### PR TITLE
EFW-1418_Barney_fix_memory_allocation

### DIFF
--- a/barney.yaml
+++ b/barney.yaml
@@ -62,7 +62,7 @@ images:
         sources:
           - github.com/untangle/support-diagnostics # to get sources under stable path
         quota:
-          memory: 25Mi
+          memory: 500Mi
           cpu: 1
         build: |
           json5 --validate /src/github.com/untangle/support-diagnostics/renovate.json5


### PR DESCRIPTION
[EFW-1418 Fix memory allocation for Barney images](https://awakesecurity.atlassian.net/browse/EFW-1418)

Too low memory quota might cause an error
```
building "code.arista.io/mfw/tests%tests/pre-merge[0]": running [sh -uxec 'ls ptest-suite '] on ref: builtin%bootstrap: failed to setup spacetime: bst exited before the setup program ran: exit status 137 Error sending the setup instructions: EOF
```

I spoke with the Barney team and got a recommendation to increase our image memory quota to 500 MiB. With more data about the actual usage in the future, we might consider decreasing it, but the current recommendation is at least 100 MiB.