### PR TITLE
NGFW-15905: prefix Renovate commit messages with ticket key

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,6 @@
 {
     "automergeSchedule": ["at any time"],
-    commitMessage: "{{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}} [skip travis]",
+    commitMessage: "NGFW-15905 {{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}} [skip travis]",
 
     packageRules: [
         {
@@ -8,7 +8,7 @@
             "matchPackageNames": ["code.arista.io/infra/barney/barnzilla-repos"],
             "automergeSchedule": ["* 0-2 * * *"],
             "timezone": "Etc/UTC",
-            commitMessage: "{{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}} [skip travis]",
+            commitMessage: "NGFW-15905 {{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}} [skip travis]",
         }
     ]
 }


### PR DESCRIPTION
Renovate bot's dependency-bump PRs now include NGFW-15905 in the commit message so ArChecks-style ticket-key validation passes without manual edits. Travis jobs fail of the last commit does not have JIRA ticket id.

Applies to both the top-level commitMessage template and the barnzilla-repos packageRules override.